### PR TITLE
Support Alpine Linux hosting k3s

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -12,7 +12,7 @@ fatal()
 }
 
 get_k3s_process_info() {
-  K3S_PID=$(ps -ef | grep -E "k3s .*(server|agent)" | grep -E -v "(init|grep|channelserver)" | awk '{print $1}')
+  K3S_PID=$(ps -ef | grep -E "k3s .*(server|agent)" | grep -E -v "(init|grep|channelserver|supervise-daemon)" | awk '{print $1}')
   if [ -z "$K3S_PID" ]; then
     fatal "K3s is not running on this server"
   fi


### PR DESCRIPTION
On Alpine Linux the supervisor daemon needs to be stripped out of the grep as it's command contains k3s.

Example of on Alpine Linux:
```
supervise-daemon k3s --start --stdout /var/log/k3s.log --stderr /var/log/k3s.log --pidfile /var/run/k3s.pid --respawn-delay 5 /usr/local/bin/k3s -- server --tls-san 185.95.218.11 --tls-san knurrli.tobrunet.ch --cluster-cidr 10.44.0.0/16 --flannel-backend wireguard
```