### PR TITLE
Improve system-upgrade script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM ${ALPINE}
 ARG ARCH
 ARG TAG
 RUN apk --no-cache add \
-    jq libselinux-utils
+  jq libselinux-utils procps
 COPY --from=verify /opt/k3s /opt/k3s
 COPY scripts/upgrade.sh /bin/upgrade.sh
 ENTRYPOINT ["/bin/upgrade.sh"]

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -13,7 +13,7 @@ fatal()
 
 get_k3s_process_info() {
   K3S_PID=$(ps -ef | grep -E "k3s .*(server|agent)" | grep -E -v "(init|grep|channelserver|supervise-daemon)" | awk '{print $2}')
-  K3S_PPID=$(ps -p $K3S_PID -o ppid=)
+  K3S_PPID=$(ps -p $K3S_PID -o ppid= | tr -s ' ')
   if [ -z "$K3S_PID" ]; then
     fatal "K3s is not running on this server"
   fi

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -12,12 +12,16 @@ fatal()
 }
 
 get_k3s_process_info() {
-  K3S_PID=$(ps -ef | grep -E "k3s .*(server|agent)" | grep -E -v "(init|grep|channelserver|supervise-daemon)" | awk '{print $1}')
+  K3S_PID=$(ps -ef | grep -E "k3s .*(server|agent)" | grep -E -v "(init|grep|channelserver|supervise-daemon)" | awk '{print $2}')
+  K3S_PPID=$(ps -p $K3S_PID -o ppid=)
   if [ -z "$K3S_PID" ]; then
     fatal "K3s is not running on this server"
   fi
   info "K3S binary is running with pid $K3S_PID"
   K3S_BIN_PATH=$(cat /host/proc/${K3S_PID}/cmdline | awk '{print $1}' | head -n 1)
+  if [ "$K3S_PPID" != "1" ]; then
+    K3S_BIN_PATH=$(cat /host/proc/${K3S_PPID}/cmdline | awk '{print $1}' | head -n 1)
+  fi
   if [ "$K3S_PID" == "1" ]; then
     # add exception for k3d clusters
     K3S_BIN_PATH="/bin/k3s"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -13,7 +13,7 @@ fatal()
 
 get_k3s_process_info() {
   K3S_PID=$(ps -ef | grep -E "k3s .*(server|agent)" | grep -E -v "(init|grep|channelserver|supervise-daemon)" | awk '{print $2}')
-  K3S_PPID=$(ps -p $K3S_PID -o ppid= | tr -s ' ')
+  K3S_PPID=$(ps -p $K3S_PID -o ppid= | xargs)
   if [ -z "$K3S_PID" ]; then
     fatal "K3s is not running on this server"
   fi


### PR DESCRIPTION
If k3s has flag `--log=/var/log/k3s-server.log` or config value `log: /var/log/k3s-server.log` the script can't upgrade k3s bin file becuase can't find correct path to binary file

When `log` is enabled :
```sh
+ upgrade
+ get_k3s_process_info
+ ps -ef
+ grep -E -v '(init|grep|channelserver|supervise-daemon)'
+ awk '{print $1}'
+ grep -E 'k3s .*(server|agent)'
+ K3S_PID=1833838
+ '[' -z 1833838 ]
+ info 'K3S binary is running with pid 1833838'
+ echo '[INFO] ' 'K3S binary is running with pid 1833838'
[INFO]  K3S binary is running with pid 1833838
+ cat /host/proc/1833838/cmdline
+ head -n 1
+ awk '{print $1}'
+ K3S_BIN_PATH=k3s
+ '[' 1833838 '==' 1 ]
+ '[' -z k3s ]
+ return
+ replace_binary
+ NEW_BINARY=/opt/k3s
+ FULL_BIN_PATH=/hostk3s
+ '[' '!' -f /opt/k3s ]
+ info 'Comparing old and new binaries'
[INFO]  Comparing old and new binaries
+ echo '[INFO] ' 'Comparing old and new binaries'
+ sha256sum /opt/k3s /hostk3s
+ wc -l
+ uniq
+ cut '-d ' -f1
sha256sum: can't open '/hostk3s': No such file or directory
[INFO]  Binary already been replaced
+ BIN_COUNT=1
+ '[' 1 '==' 1 ]
+ info 'Binary already been replaced'
+ echo '[INFO] ' 'Binary already been replaced'
+ exit 0
```
As you see the error is `sha256sum: can't open '/hostk3s': No such file or directory`

Example command:
```sh
NODE-with-log-flag# ps -ef | grep -E "k3s .*(server|agent)" | grep -E -v "(init|grep|channelserver|supervise-daemon)"
root     3259747 3259736 33 09:08 ?        00:12:16 k3s server
```
As you see the PPID is `3259736`
```sh
NODE-with-log-flag# ps -ef | grep 3259736
root     3259736       1  0 09:08 ?        00:00:03 /usr/local/bin/k3s init
root     3259747 3259736 30 09:08 ?        00:44:41 k3s server
```

Another k3s node. It has correct path to binary file `/usr/local/bin/k3s`
```sh
NODE-without-log-flagu# ps -ef | grep -E "k3s .*(server|agent)" | grep -E -v "(init|grep|channelserver|supervise-daemon)"
root     1367009       1 43 09:07 ?        00:16:07 /usr/local/bin/k3s server
```

This PR should fix the issue. It install new pkg `procps` to check PPID
Example how it works with changes:
```sh
$ kubectl logs apply-k3s-server-on-ip-****
+ upgrade
+ get_k3s_process_info
+ ps -ef
+ awk '{print $2}'
+ grep -E -v '(init|grep|channelserver|supervise-daemon)'
+ grep -E 'k3s .*(server|agent)'
+ K3S_PID=3259747
+ ps -p 3259747 -o 'ppid='
+ K3S_PPID=3259736
+ '[' -z 3259747 ]
+ info 'K3S binary is running with pid 3259747'
+ echo '[INFO] ' 'K3S binary is running with pid 3259747'
[INFO]  K3S binary is running with pid 3259747
+ cat /host/proc/3259747/cmdline
+ head -n 1
+ awk '{print $1}'
+ K3S_BIN_PATH=k3s
+ '[' 3259736 '!=' 1 ]
+ cat+  /host/proc/3259736/cmdlinehead -n 1

+ awk '{print $1}'
+ K3S_BIN_PATH=/usr/local/bin/k3s
+ '[' 3259747 '==' 1 ]
+ '[' -z /usr/local/bin/k3s ]
+ return
+ replace_binary
+ NEW_BINARY=/opt/k3s
+ FULL_BIN_PATH=/host/usr/local/bin/k3s
+ '[' '!' -f /opt/k3s ]
+ info 'Comparing old and new binaries'
+ echo '[INFO] ' 'Comparing old and new binaries'
[INFO]  Comparing old and new binaries
+ sha256sum /opt/k3s /host/usr/local/bin/k3s
+ + uniq
+ cutwc '-d ' -l -f1

[INFO]  Binary already been replaced
+ BIN_COUNT=1
+ '[' 1 '==' 1 ]
+ info 'Binary already been replaced'
+ echo '[INFO] ' 'Binary already been replaced'
+ exit 0
```