### PR TITLE
Update Alpine version to 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE=alpine:3.15.4
+ARG ALPINE=alpine:3.16.2
 FROM ${ALPINE} AS verify
 ARG ARCH
 ARG TAG

--- a/Dockerfile.manifest
+++ b/Dockerfile.manifest
@@ -1,4 +1,4 @@
-FROM golang:1.13.6-alpine3.10
+FROM golang:1.18.5-alpine3.16
 
 COPY --from=plugins/manifest:1.2.3 /bin/* /bin/
 


### PR DESCRIPTION
Update Alpine version to 3.16 to get recent security updates.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>