### PR TITLE
Handle ps output matching multiple k3s pids

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE=alpine:3.16.2
+ARG ALPINE=alpine:3.17.2
 FROM ${ALPINE} AS verify
 ARG ARCH
 ARG TAG

--- a/Dockerfile.manifest
+++ b/Dockerfile.manifest
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-alpine3.16
+FROM alpine:3.17.2
 
 COPY --from=plugins/manifest:1.2.3 /bin/* /bin/
 


### PR DESCRIPTION
* Handle and add tracing when we find multiple k3s pids.
* Migrate from master to control-plane labels, as we are no longer supporting any releases that only have the master label.
* Bump alpine tag.

Linked issue:
* https://github.com/k3s-io/k3s/issues/2007