### PR TITLE
Bump Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-ARG ALPINE=alpine:3.17.2
+ARG ALPINE=alpine:3.20
 FROM ${ALPINE} AS verify
 ARG ARCH
 ARG TAG
 WORKDIR /verify
 ADD https://github.com/k3s-io/k3s/releases/download/${TAG}/sha256sum-${ARCH}.txt .
 RUN set -x \
- && apk --no-cache add \
-    curl \
-    file
+ && apk upgrade -U \
+ && apk add \
+    curl file \
+ && apk cache clean \
+ && rm -rf /var/cache/apk/*
 RUN if [ "${ARCH}" == "amd64" ]; then \
       export ARTIFACT="k3s"; \
     elif [ "${ARCH}" == "arm" ]; then \
@@ -26,8 +28,11 @@ RUN if [ "${ARCH}" == "amd64" ]; then \
 FROM ${ALPINE}
 ARG ARCH
 ARG TAG
-RUN apk --no-cache add \
-  jq libselinux-utils procps
+RUN apk upgrade -U \
+ && apk add \
+    jq libselinux-utils procps \
+ && apk cache clean \
+ && rm -rf /var/cache/apk/*
 COPY --from=verify /opt/k3s /opt/k3s
 COPY scripts/upgrade.sh /bin/upgrade.sh
 ENTRYPOINT ["/bin/upgrade.sh"]

--- a/Dockerfile.manifest
+++ b/Dockerfile.manifest
@@ -1,4 +1,4 @@
-FROM alpine:3.18.4
+FROM alpine:3.20
 
 COPY --from=plugins/manifest:1.2.3 /bin/* /bin/
 
@@ -10,6 +10,10 @@ ENV DOCKER_PASSWORD $DOCKER_PASSWORD
 
 ARG DRONE_TAG
 ENV DRONE_TAG $DRONE_TAG
+
+RUN apk upgrade -U \
+ && apk cache clean \
+ && rm -rf /var/cache/apk/*
 
 COPY ./scripts/manifest /bin/
 


### PR DESCRIPTION
- Bump Alpine version to `3.20`.
- Add `apk upgrade` to upgrade all the packages during image build. The current images are using Alpine `3.17.2`, which is an older patch version. The `upgrade` will help bump the packages (and fix some CVEs), even if the patch version drifts.