### PR TITLE
Fix error message in upgrade.sh for version comparison

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -82,18 +82,15 @@ replace_binary() {
   fi
 
   set +e
-  
-  NEW_BIN_VERSION="$($NEW_BINARY -v | head -1)"
-  NEW_BIN_SEMVER="$(echo $NEW_BIN_VERSION | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
 
-  FULL_BIN_VERSION="$($FULL_BIN_PATH -v | head -1)"
-  FULL_BIN_SEMVER="$(echo $FULL_BIN_VERSION | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
+  NEW_BIN_SEMVER="$($NEW_BINARY -v | head -1)"
+  FULL_BIN_SEMVER="$($FULL_BIN_PATH -v | head -1)"
 
   # Returns 0 if version1 <= version2, 1 otherwise
   compare_versions "$FULL_BIN_SEMVER" "$NEW_BIN_SEMVER"
 
   if [ $? -eq 1 ]; then
-    echo "Error: Current ${FULL_BIN_VERSION} is higher than ${NEW_BIN_VERSION}"
+    echo "Error: Current ${FULL_BIN_SEMVER} is higher than ${NEW_BIN_SEMVER}"
     exit 1
   fi
 

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -82,15 +82,18 @@ replace_binary() {
   fi
 
   set +e
+  
+  NEW_BIN_VERSION="$($NEW_BINARY -v | head -1)"
+  NEW_BIN_SEMVER="$(echo $NEW_BIN_VERSION | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
 
-  NEW_BIN_SEMVER="$($NEW_BINARY -v | head -1)"
-  FULL_BIN_SEMVER="$($FULL_BIN_PATH -v | head -1)"
+  FULL_BIN_VERSION="$($FULL_BIN_PATH -v | head -1)"
+  FULL_BIN_SEMVER="$(echo $FULL_BIN_VERSION | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
 
   # Returns 0 if version1 <= version2, 1 otherwise
   compare_versions "$FULL_BIN_SEMVER" "$NEW_BIN_SEMVER"
 
   if [ $? -eq 1 ]; then
-    echo "Error: Current version ${FULL_BIN_SEMVER} is higher than ${NEW_BIN_SEMVER}"
+    echo "Error: Current ${FULL_BIN_VERSION} is higher than ${NEW_BIN_VERSION}"
     exit 1
   fi
 


### PR DESCRIPTION
## Issue
When attempting to upgrade a cluster running a newer version to an older one, 
the error message has a grammatical error: 
"Current version k3s version" instead of "Current k3s version".

## Changes
- Modified how version information is collected and displayed in the error message
- Changed the error text to be grammatically correct

## Testing
Tested by attempting to downgrade a v1.32.2+k3s1 cluster to v1.30, 
confirming the error message is now properly formatted.

Fixes k3s-io/k3s#12027