### PR TITLE
Ignore patch versions for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
     directory: "/"
     labels:
       - "kind/dependabot"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     reviewers:
       - "k3s-io/k3s-dev"
     schedule:


### PR DESCRIPTION
We don't need dependabot to open weekly patches for actions, minors are good enough.